### PR TITLE
release v0.3.0

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -32,5 +32,6 @@ jobs:
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
           gem push *.gem
+        continue-on-error: true
         env:
           GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+- remove 'tanita-api-client' dependency.
+- rename module 'Omniauth' to 'OmniAuth'.
+- update gem-push GitHub Actions settings in order to ignore error for same version.
+
 # 0.2.3
 
 - refs #1 setup GitHub Actions for rspec and pushing to RubyGems.

--- a/lib/omniauth-tanita/version.rb
+++ b/lib/omniauth-tanita/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Tanita
-    VERSION = '0.2.3'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/omniauth-tanita/version.rb
+++ b/lib/omniauth-tanita/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Omniauth
+module OmniAuth
   module Tanita
     VERSION = '0.2.3'
   end

--- a/lib/omniauth/strategies/tanita.rb
+++ b/lib/omniauth/strategies/tanita.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
 require 'omniauth-oauth2'
-require 'tanita/api/client'
 
 module OmniAuth
   module Strategies
-    TANITA = Tanita::Api::Client
-
+    # OmniAuth strategy for Health Planet
     class Tanita < OmniAuth::Strategies::OAuth2
       option :name, 'tanita'
 
       option :skip_info, true
       option :provider_ignores_state, true
-      option :scope, TANITA::Scope::INNERSCAN
+      option :scope, 'innerscan'
 
-      option :client_options, :site => TANITA::BASE_URL,
-               :authorize_url => TANITA::AUTH_URL_PATH,
-               :token_url => TANITA::TOKEN_URL_PATH
+      option :client_options, :site => 'https://www.healthplanet.jp',
+               :authorize_url => '/oauth/auth'
+
+    private
 
       def callback_url
         full_host + script_name + callback_path
-     end
-
+      end
     end
   end
 end

--- a/omniauth-tanita.gemspec
+++ b/omniauth-tanita.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'tanita-api-client', '~> 0.2.3'
   spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.6.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/omniauth-tanita.gemspec
+++ b/omniauth-tanita.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/omniauth-tanita/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-tanita'
-  spec.version       = Omniauth::Tanita::VERSION
+  spec.version       = OmniAuth::Tanita::VERSION
   spec.authors       = ['Kenji Koshikawa']
   spec.email         = ['koshikawa2009@gmail.com']
 

--- a/spec/omniauth/strategies/tanita_spec.rb
+++ b/spec/omniauth/strategies/tanita_spec.rb
@@ -9,15 +9,15 @@ describe OmniAuth::Strategies::Tanita do
 
   context 'client options' do
     it 'has correct site' do
-      expect(subject.client.site).to eq(Tanita::Api::Client::BASE_URL)
+      expect(subject.client.site).to eq('https://www.healthplanet.jp')
     end
 
     it 'has correct authorize_url' do
-      expect(subject.client.options[:authorize_url]).to eq(Tanita::Api::Client::AUTH_URL_PATH)
+      expect(subject.client.options[:authorize_url]).to eq('/oauth/auth')
     end
 
     it 'has correct token_url' do
-      expect(subject.client.options[:token_url]).to eq(Tanita::Api::Client::TOKEN_URL_PATH)
+      expect(subject.client.options[:token_url]).to eq('/oauth/token')
     end
 
     it 'has default skip_info' do
@@ -27,13 +27,17 @@ describe OmniAuth::Strategies::Tanita do
     it 'has default provider_ignores_state' do
       expect(subject.options[:provider_ignores_state]).to eq(true)
     end
+
+    it 'has default scope' do
+      expect(subject.options[:scope]).to eq('innerscan')
+    end
   end
 
   describe '#callback_url' do
     it 'returns callback url' do
       allow(subject).to receive(:full_host) { 'http://localhost' }
       allow(subject).to receive(:script_name) { '/v1' }
-      expect(subject.callback_url).to eq 'http://localhost/v1/auth/tanita/callback'
+      expect(subject.send(:callback_url)).to eq 'http://localhost/v1/auth/tanita/callback'
     end
   end
 end


### PR DESCRIPTION
- remove 'tanita-api-client' dependency.
- rename module 'Omniauth' to 'OmniAuth'.
- update gem-push GitHub Actions settings in order to ignore error for same version.
